### PR TITLE
Rails: Load rake tasks in the engine

### DIFF
--- a/lib/tasks/vapey/rails_tasks.rake
+++ b/lib/tasks/vapey/rails_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :vapey_rails do
-#   # Task goes here
-# end

--- a/lib/vapey/engine.rb
+++ b/lib/vapey/engine.rb
@@ -1,5 +1,10 @@
 module Vapey
   class Engine < ::Rails::Engine
     isolate_namespace Vapey
+
+    rake_tasks do
+      path = File.expand_path(__dir__)
+      Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+    end
   end
 end

--- a/lib/vapey/tasks/vapey.rake
+++ b/lib/vapey/tasks/vapey.rake
@@ -1,0 +1,6 @@
+namespace :vapey do
+  desc "Reindex"
+  task :reindex do
+    # Task goes here
+  end
+end


### PR DESCRIPTION
By adding the rake tasks in the engine, it makes Rails load them properly so the rails CLI can pick it up.

With these changes, you can do `rails vapey:reindex` and it will run this task.

If you run `rails` alone, the task will also be listed like all the others.

I changed the directory of the tasks as tasks that are required at runtime are usually located under lib/gem_name.

Tasks that are used for development purposes or that want to be excluded from the bundled gem are usually set under lib/tasks.